### PR TITLE
Rewrote handling of "-0.0" strings to be locale independent.

### DIFF
--- a/src/com/bfv/view/FieldManager.java
+++ b/src/com/bfv/view/FieldManager.java
@@ -298,8 +298,8 @@ public class FieldManager {
         value = value * field.getUnitMultiplier(multiplierIndex);
 
         String ret = df.format(value);
-        if (ret.equals("-0.0")) {
-            ret = "0.0";
+        if (ret.equals(df.format(-Double.MIN_VALUE))) {
+            ret = df.format(0.0);
         }
 
         return ret;

--- a/src/com/bfv/view/component/VarioTraceViewComponent.java
+++ b/src/com/bfv/view/component/VarioTraceViewComponent.java
@@ -199,8 +199,8 @@ public class VarioTraceViewComponent extends BFVViewComponent {
         canvas.drawRect(markRect, paint);
 
         String text = dfVarioScale1.format(scaleVar.getValue());
-        if (text.equals("-0.0")) {
-            text = "0.0";
+        if (text.equals(dfVarioScale1.format(-Double.MIN_VALUE))) {
+            text = dfVarioScale1.format(0.0);
         }
         paint.setStyle(Paint.Style.FILL);
         paint.getTextBounds(text, 0, text.length(), textBounds);


### PR DESCRIPTION
Hi, I have my HTC One X Android phone set to the Swedish locale. Small negative values are displayed as "−0,0" where there's both a decimal comma instead of a decimal point, and also the minus sign is a special unicode character.

I think I found a way to handle the different locale cases gracefully with this code change. It should also handle any number of decimals (not tested). It seems to work on my phone and I believe it is bug free, but I can't guarantee that since I'm new to Java and Android / ARM.

Hopefully this patch is useful, but don't hesitate to reject it if it needs more work.

Best regards, Krister
